### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Slack Conversation Library for ClaudeAI.
 ```bash
 npm install claude-api
 // or
-yarn install claude-api
+yarn add claude-api
 ```
 
 ```js


### PR DESCRIPTION
`install` has been replaced with `add` to add new dependencies. Run "yarn add claude-api" instead.